### PR TITLE
make game board compatible with firefox

### DIFF
--- a/src/components/Board/Board.module.scss
+++ b/src/components/Board/Board.module.scss
@@ -30,7 +30,9 @@
         margin: 0.1rem;
         cursor: default;
         height: -webkit-fill-available;
+        height: -moz-available;
         width: -webkit-fill-available;
+        width: -moz-available;
       }
   
       &>input[type=number] {
@@ -40,7 +42,9 @@
         padding: 0.1rem;
         margin: 0.1rem;
         height: -webkit-fill-available;
+        height: -moz-available;
         width: -webkit-fill-available;
+        width: -moz-available;
         
         color: blue;
 


### PR DESCRIPTION
width and height also use -moz prefixed rules, then it looks and feels nice in firefox.